### PR TITLE
Perform post-package install steps under security disabler

### DIFF
--- a/Source/FortisCollections.Toolcore.Update/PackageInstaller.cs
+++ b/Source/FortisCollections.Toolcore.Update/PackageInstaller.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Sitecore.SecurityModel;
 using Sitecore.Update;
 using Sitecore.Update.Installer;
 
@@ -72,7 +73,11 @@ namespace FortisCollections.Toolcore.Update
 				var entries = UpdateHelper.Install(packageInstallationInfo, logger, out historyPath);
 				var installer = new DiffInstaller(packageInstallationInfo.Action);
 
-				installer.ExecutePostInstallationInstructions(packageInstallationInfo.Path, historyPath, packageInstallationInfo.Mode, packageMetaData, logger, ref entries);
+				using (new SecurityDisabler())
+				{
+					installer.ExecutePostInstallationInstructions(packageInstallationInfo.Path, historyPath,
+						packageInstallationInfo.Mode, packageMetaData, logger, ref entries);
+				}
 
 				ActiveTracker.Tracker = null;
 


### PR DESCRIPTION
We have found that the post-install steps for TDS update packages are failing due to a lack of permissions.  This occurs when TDS is configured to recycle or delete items not found in the update package during the install.  Running the post-install steps under the SecurityDisabler allows for the delete/recycling to take place.